### PR TITLE
Fixed ClassCastException with PortletService.getWarPortlets() 

### DIFF
--- a/src/com/liferay/mobile/sdk/util/LanguageUtil.java
+++ b/src/com/liferay/mobile/sdk/util/LanguageUtil.java
@@ -72,6 +72,7 @@ public class LanguageUtil {
 	public boolean isArray(String type) {
 		if (type.endsWith("[]") || type.equals("object<list>") ||
 			type.equals("object<com.liferay.portal.kernel.json.JSONArray>") ||
+			type.startsWith("java.util.Collection") ||
 			type.startsWith("list")) {
 
 			return true;


### PR DESCRIPTION
Previously the PortletService.getWarPortlets() would through a ClassCastException because the generated API was expected the server to return a JSONObject but it returns a JSONArray instead.

This commit changes the code generation to generate PortletService.getWarPortlets() to have proper JSONArray return type.

However, I'm not sure what other methods would be selected.  I did some research and there seemed to be 1 or 2 more methods that had type=="java.util.Collection..." but were returning JSONObject.  Likely those APIs were also incorrect.  Hopefully this change will fix those as well.
