### PR TITLE
Updating references for Liferay Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ The Liferay open-source community has built SDKs for different platforms as
 well:
 
 - [PhoneGap](https://github.com/salvatejero/cordova-liferay-plugin) (by Salva Tejero)
-- [Titanium](https://www.npmjs.org/package/liferay-connector) (by Pier Paolo Ramon)
+- [Titanium SDK](https://github.com/smclab/liferay-connector) (by SMC, maintained by Pier Paolo Ramon)
 - [Windows](https://github.com/Ithildir/liferay-sdk-builder-windows) (by Andrea Di Giorgi)


### PR DESCRIPTION
Pointing to the npm package is valid almost exclusively for Node.js, which is not even stated as a supported platform for Liferay Connector. But we all know it is :)