### PR TITLE
Same session with different credentials fix

### DIFF
--- a/ios/Source/Http/LRHttpUtil.m
+++ b/ios/Source/Http/LRHttpUtil.m
@@ -177,7 +177,7 @@ typedef void (^LRHandler)(
 	};
 
 	NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration
-		defaultSessionConfiguration];
+		ephemeralSessionConfiguration];
 
 	LRRedirectDelegate *delegate = [[LRRedirectDelegate alloc] init];
 


### PR DESCRIPTION
Noticed that after login with 2 different users the JSESSIONID was the same, so found that ephemeralSessionConfiguration fixes that issue because on every request sends clean data instead of sending the same session every time in the server request,

Steps to reproduce:
found that calling service with user A worked fine but when calling service with user B, server assumes is user A because of same JSESSIONID in the request cookie

Thanks in advance,