### PR TITLE
Add check to support version 62

### DIFF
--- a/android/src/main/java/com/liferay/mobile/android/service/BaseService.java
+++ b/android/src/main/java/com/liferay/mobile/android/service/BaseService.java
@@ -46,7 +46,7 @@ public class BaseService {
 		throws JSONException {
 
 		if (wrapper == null) {
-			if (!className.equals(_SERVICE_CONTEXT)) {
+			if (!className.equals(_SERVICE_CONTEXT_70) && !className.equals(_SERVICE_CONTEXT_62)) {
 				params.put(name, JSONObject.NULL);
 			}
 
@@ -82,7 +82,10 @@ public class BaseService {
 
 	protected Session session;
 
-	private static final String _SERVICE_CONTEXT =
+	private static final String _SERVICE_CONTEXT_62 =
+		"com.liferay.portal.service.ServiceContext";
+
+	private static final String _SERVICE_CONTEXT_70 =
 		"com.liferay.portal.kernel.service.ServiceContext";
 
 }

--- a/ios/Source/Core/LRBaseService.m
+++ b/ios/Source/Core/LRBaseService.m
@@ -15,7 +15,8 @@
 #import "LRBaseService.h"
 #import "LRValidator.h"
 
-NSString *const _SERVICE_CONTEXT = @"com.liferay.portal.kernel.service.ServiceContext";
+NSString *const _SERVICE_CONTEXT_62 = @"com.liferay.portal.service.ServiceContext";
+NSString *const _SERVICE_CONTEXT_70 = @"com.liferay.portal.kernel.service.ServiceContext";
 
 /**
  * @author Bruno Farache
@@ -49,7 +50,8 @@ NSString *const _SERVICE_CONTEXT = @"com.liferay.portal.kernel.service.ServiceCo
 		wrapper:(LRJSONObjectWrapper *)wrapper {
 
 	if (!wrapper) {
-		if (![className isEqualToString:_SERVICE_CONTEXT]) {
+		if (![className isEqualToString:_SERVICE_CONTEXT_62] &&
+			![className isEqualToString:_SERVICE_CONTEXT_70]) {
 			[params setObject:[NSNull null] forKey:name];
 		}
 


### PR DESCRIPTION
Hi!

The SDK is falling in calls to ServiceContext in portal 62 because it checks against the 70 classname. We could also check by contains ServiceContext.