### PR TITLE
Change email validation regexp

### DIFF
--- a/ios/Source/Util/LRValidator.m
+++ b/ios/Source/Util/LRValidator.m
@@ -20,8 +20,8 @@
 @implementation LRValidator
 
 + (BOOL)isEmailAddress:(NSString *)emailAddress {
-	NSString *regex = @"[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}";
-
+	NSString *regex = @"[\\w!#$%&'*+/=?^_`{|}~-]+(?:\\.[\\w!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-zA-Z0-9](?:-*[a-zA-Z0-9])?\\.*)+";
+	
 	NSPredicate *predicate = [NSPredicate
 		predicateWithFormat:@"SELF MATCHES %@", regex];
 	


### PR DESCRIPTION
I discovered this while implementing Liferay API communication in an app. The validator class didn't recognize a valid email address with a 4+ character TLD.

The regexp originally used is a bit too restrictive, especially with limiting the TLD to be between 2 and 4 characters long, which by today's standards isn't a good assumption. As proof, here's the current IANA list for TLDs: https://data.iana.org/TLD/tlds-alpha-by-domain.txt

Also, I checked the Android source code in Java and I noticed that a different, less restrictive pattern was used there.

In the proposed change, I decided to copy the Java code regexp and replaced the one used in the iOS version.