### PR TITLE
Checking *error

### DIFF
--- a/ios/Source/Http/LRHttpUtil.m
+++ b/ios/Source/Http/LRHttpUtil.m
@@ -103,7 +103,7 @@ typedef void (^LRHandler)(
 	NSData *body = [NSJSONSerialization dataWithJSONObject:commands options:0
 		error:error];
 
-	if (*error) {
+	if (body == nil) {
 		return nil;
 	}
 


### PR DESCRIPTION
During development, I've encountered problem which resulted that application does nothing. After investigation I've discovered that dataWithJSONObject returns error and the valid object. Apple in docs suggest to check returned object, instead of checking error which can be anything. I've discovered couple files where simmilar pattern is used, but this is most valuable place which can be affected by any api call.

https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/ErrorHandling/ErrorHandling.html
http://stackoverflow.com/questions/25558442/can-reusing-the-same-nserror-object-be-problematic