### PR TITLE
Fix bug when calling gradle in daemon mode

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -112,6 +112,11 @@ it needs to generate code for your portlet. If for some reason you need more
 control over these properties, run the same command with the `all` argument:
 
     ./gradlew createModule -P=all
+    
+> If you receive an "Error while getting console" message. Make the call in no daemon mode:
+>
+>    ./gradlew createModule --no-daemon
+>    
 
 It should print out something like this:
 


### PR DESCRIPTION
If you call the "createModule" task with a daemon running you won't have access to the System.Console, and therefore you will receive an "Error while getting console" error.

The solution to this bug is answered in this thread:
http://stackoverflow.com/questions/19487576/gradle-build-null-console-object