### PR TITLE
Fix cookie auth in liferay 6.2

### DIFF
--- a/ios/Source/Core/Auth/LRCookieSignIn.h
+++ b/ios/Source/Core/Auth/LRCookieSignIn.h
@@ -26,7 +26,7 @@
  */
 @interface LRCookieSignIn : NSObject
 
-+ (void)signInWithSession:(LRSession *)session
+- (void)signInWithSession:(LRSession *)session
 	callback:(id<LRCookieCallback>)callback;
 
 @end

--- a/ios/Source/Core/Auth/LRCookieSignIn.m
+++ b/ios/Source/Core/Auth/LRCookieSignIn.m
@@ -133,6 +133,21 @@ const int AUTH_TOKEN_LENGTH = 8;
 	[task resume];
 }
 
+- (void) URLSession:(NSURLSession *)session
+		task:(NSURLSessionTask *)task
+		willPerformHTTPRedirection:(NSHTTPURLResponse *)response
+		newRequest:(NSURLRequest *)request
+		completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
+
+	NSString *cookies = [self _getHttpCookies:
+			[NSHTTPCookieStorage sharedHTTPCookieStorage] requestURL:response.URL];
+
+	NSMutableURLRequest *mutableRequest = request.mutableCopy;
+
+	[mutableRequest addValue:[NSString stringWithFormat:@"%@", cookies] forHTTPHeaderField:@"Cookie"];
+
+	completionHandler(mutableRequest);
+}
 - (NSString *)_getAuthToken:(NSData *)htmlData {
 	NSString *html = [[NSString alloc]initWithData:htmlData
 		encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
Hi!
Sorry for the multiple PR's
I was having a problem to use cookie login in 6.2 URLSession without a delegate was not setting the cookings correctly in redirects.
I had to change the callback based method in urlsession for the delegate one.

I hope you find the changes fine :)
Regards!
