### PR TITLE
Allow developers to handle authentication challenges in cookie login

### DIFF
--- a/ios/Source/Core/Auth/LRCookieSignIn.h
+++ b/ios/Source/Core/Auth/LRCookieSignIn.h
@@ -29,4 +29,9 @@
 + (void)signInWithSession:(LRSession *)session
 	callback:(id<LRCookieCallback>)callback;
 
++ (void)signInWithSession:(LRSession *)session
+	callback:(id<LRCookieCallback>)callback
+	challengeBlock: (void (^)(NSURLAuthenticationChallenge *challenge,
+		void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))) challengeBlock;
+
 @end

--- a/ios/Source/Core/Auth/LRCookieSignIn.h
+++ b/ios/Source/Core/Auth/LRCookieSignIn.h
@@ -32,6 +32,6 @@
 + (void)signInWithSession:(LRSession *)session
 	callback:(id<LRCookieCallback>)callback
 	challengeBlock: (void (^)(NSURLAuthenticationChallenge *challenge,
-		void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))) challengeBlock;
+		void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))) challengeBlock;
 
 @end

--- a/ios/Source/Core/Auth/LRCookieSignIn.m
+++ b/ios/Source/Core/Auth/LRCookieSignIn.m
@@ -29,7 +29,7 @@ const int AUTH_TOKEN_LENGTH = 8;
 @property (nonatomic, copy) NSString *password;
 @property (nonatomic) NSMutableData *responseData;
 @property (nonatomic) void (^challengeBlock)(NSURLAuthenticationChallenge *challenge,
-		void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable));
+		void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *));
 
 @end
 
@@ -57,7 +57,7 @@ const int AUTH_TOKEN_LENGTH = 8;
 		callback:(id<LRCookieCallback>)callback
 		challengeBlock: (void (^)(NSURLAuthenticationChallenge *challenge,
 			void (^)(NSURLSessionAuthChallengeDisposition,
-			NSURLCredential * _Nullable))) challengeBlock {
+			NSURLCredential *))) challengeBlock {
 
 	LRCookieSignIn *cookieSignIn = [[LRCookieSignIn alloc] init];
 	cookieSignIn.challengeBlock = challengeBlock;
@@ -69,7 +69,7 @@ const int AUTH_TOKEN_LENGTH = 8;
 		task:(NSURLSessionTask *)task
 		willPerformHTTPRedirection:(NSHTTPURLResponse *)response
 		newRequest:(NSURLRequest *)request
-		completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
+		completionHandler:(void (^)(NSURLRequest *))completionHandler {
 
 	NSString *cookies = [self _getHttpCookies:
 		[NSHTTPCookieStorage sharedHTTPCookieStorage]
@@ -86,7 +86,7 @@ const int AUTH_TOKEN_LENGTH = 8;
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task
 		didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 		completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition,
-			NSURLCredential * _Nullable))completionHandler {
+			NSURLCredential *))completionHandler {
 
 	if (challenge.previousFailureCount == 0) {
 		if (self.challengeBlock) {

--- a/ios/Source/Core/Auth/LRCookieSignIn.m
+++ b/ios/Source/Core/Auth/LRCookieSignIn.m
@@ -97,9 +97,10 @@ const int AUTH_TOKEN_LENGTH = 8;
 		}
 	}
 	else {
-		[self.callback onFailure:[LRError errorWithCode:challenge.failureResponse
+		NSHTTPURLResponse *response = (NSHTTPURLResponse *)challenge.failureResponse;
+		[self.callback onFailure:[LRError errorWithCode:response.statusCode
 			description:@"Error authenticating"
-			userInfo:@{@"underlyingResponse": challenge.failureResponse}]];
+			userInfo:@{@"underlyingResponse": response}]];
 	}
 }
 

--- a/ios/Source/Core/Auth/LRCookieSignIn.m
+++ b/ios/Source/Core/Auth/LRCookieSignIn.m
@@ -94,6 +94,12 @@ const int AUTH_TOKEN_LENGTH = 8;
 	else {
 		NSString *authToken = [self _getAuthToken:self.responseData];
 
+		if (!authToken) {
+			error = [LRError errorWithCode:400 description:@"Failed to get the auth token"];
+			[self.callback onFailure:error];
+			return;
+		}
+
 		NSString *cookieHeader =
 			[self _getHttpCookies:[NSHTTPCookieStorage sharedHTTPCookieStorage]
 				requestURL:task.response.URL];
@@ -119,8 +125,12 @@ const int AUTH_TOKEN_LENGTH = 8;
 		encoding:NSUTF8StringEncoding];
 
 	NSRange range = [html rangeOfString:@"Liferay.authToken=\""];
-	range = NSMakeRange(range.location + range.length, AUTH_TOKEN_LENGTH);
 
+	if (range.location == NSNotFound) {
+		return nil;
+	}
+
+	range = NSMakeRange(range.location + range.length, AUTH_TOKEN_LENGTH);
 	return [html substringWithRange:range];
 }
 


### PR DESCRIPTION
Hey!

This PR add a new parameter to the cookie login method, a block, to let the user handle the authentication challenges :)

