### PR TITLE
Fix auth token parsing

### DIFF
--- a/android/src/main/java/com/liferay/mobile/android/auth/CookieSignIn.java
+++ b/android/src/main/java/com/liferay/mobile/android/auth/CookieSignIn.java
@@ -140,16 +140,8 @@ public class CookieSignIn {
 			throw new AuthenticationException("Cookie invalid or empty");
 		}
 
-		Pattern tokenPattern = Pattern.compile(".*Liferay.authToken\\s*=\\s*[\"'](.{8})[\"'].*");
 		String body = response.body().string();
-
-		Matcher matcher = tokenPattern.matcher(body);
-
-		if (!matcher.find()) {
-			throw new AuthenticationException("Cookie invalid or empty");
-		}
-
-		String authToken = matcher.group(1);
+		String authToken = parseAuthToken(body);
 		String cookieHeader = getHttpCookies(cookieManager.getCookieStore());
 
 		if (Validator.isNotNull(cookieHeader)) {
@@ -161,6 +153,18 @@ public class CookieSignIn {
 		else {
 			throw new AuthenticationException("Cookie invalid or empty");
 		}
+	}
+
+	protected static String parseAuthToken(String body) throws IOException, AuthenticationException {
+		Pattern tokenPattern = Pattern.compile(".*Liferay.authToken\\s*=\\s*[\"'](.{8})[\"'].*");
+
+		Matcher matcher = tokenPattern.matcher(body);
+
+		if (!matcher.find()) {
+			throw new AuthenticationException("Cookie invalid or empty");
+		}
+
+		return matcher.group(1);
 	}
 
 	protected String getBody(String username, String password)

--- a/android/src/test/java/com/liferay/mobile/android/ParseAuthTokenTest.java
+++ b/android/src/test/java/com/liferay/mobile/android/ParseAuthTokenTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ * <p>
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * <p>
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.mobile.android.auth;
+
+import com.liferay.mobile.android.exception.AuthenticationException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Víctor Galán
+ */
+public class ParseAuthTokenTest {
+
+    @Test
+    public void parseAuthTokenWithQuotes() throws Exception {
+        String tokenString = "Liferay.authToken=\"12345678\"";
+
+        String parsedToken = CookieSignIn.parseAuthToken(tokenString);
+
+        assertEquals("12345678", parsedToken);
+    }
+
+    @Test
+    public void parseAuthTokenWithSingleQuotes() throws Exception {
+        String tokenString = "Liferay.authToken='12345678'";
+
+        String parsedToken = CookieSignIn.parseAuthToken(tokenString);
+
+        assertEquals("12345678", parsedToken);
+    }
+
+    @Test
+    public void parseAuthTokenWithSingleQuotesAndSpaces() throws Exception {
+        String tokenString = "Liferay.authToken    =   '12345678'";
+
+        String parsedToken = CookieSignIn.parseAuthToken(tokenString);
+
+        assertEquals("12345678", parsedToken);
+    }
+
+    @Test
+    public void parseAuthTokenWithQuotesAndSpaces() throws Exception {
+        String tokenString = "Liferay.authToken    =   \"12345678\"";
+
+        String parsedToken = CookieSignIn.parseAuthToken(tokenString);
+
+        assertEquals("12345678", parsedToken);
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void parseAuthTokenWithoutToken() throws Exception {
+        String tokenString = "This is a string without token";
+
+        String parsedToken = CookieSignIn.parseAuthToken(tokenString);
+
+        assertEquals("12345678", parsedToken);
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void parseAuthTokenWithIncorrectToken() throws Exception {
+        String tokenString = "Liferay.authToken = \"12345\"";
+
+        String parsedToken = CookieSignIn.parseAuthToken(tokenString);
+
+        assertEquals("12345678", parsedToken);
+    }
+
+    @Test
+    public void parseAuthTokenInsideMoreText() throws Exception {
+        String tokenString = "This is more test stringLiferay.authToken = \"12345678\"This is more test string";
+
+        String parsedToken = CookieSignIn.parseAuthToken(tokenString);
+
+        assertEquals("12345678", parsedToken);
+    }
+}

--- a/ios/Liferay iOS SDK.xcodeproj/project.pbxproj
+++ b/ios/Liferay iOS SDK.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0B57EC291D9AA80E00D0AD23 /* LRCookieAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B57EC281D9AA80E00D0AD23 /* LRCookieAuthentication.m */; };
 		0B57EC2C1D9AA81D00D0AD23 /* LRCookieSignIn.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B57EC2B1D9AA81D00D0AD23 /* LRCookieSignIn.m */; };
 		0B57EC2E1D9AA86800D0AD23 /* CookieAuthenticationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B57EC2D1D9AA86800D0AD23 /* CookieAuthenticationTest.m */; };
+		0B6268621EE9AAF500B81D67 /* ParseAuthTokenTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B6268611EE9AAF500B81D67 /* ParseAuthTokenTest.m */; };
 		87C8D0C95025EA314CC11BBC /* libPods-mobile-sdk-Liferay iOS SDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D12B01AB1138179D989511F7 /* libPods-mobile-sdk-Liferay iOS SDK.a */; };
 		C42E38B6066A8FEA9F781821 /* libPods-mobile-sdk-Test.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C7ED85BFD06170E8C7DA6BA2 /* libPods-mobile-sdk-Test.a */; };
 		CC03FB6F18ED7BA000F3F16C /* settings.plist in Resources */ = {isa = PBXBuildFile; fileRef = CC03FB6C18ED7BA000F3F16C /* settings.plist */; };
@@ -291,6 +292,7 @@
 		0B57EC2B1D9AA81D00D0AD23 /* LRCookieSignIn.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LRCookieSignIn.m; sourceTree = "<group>"; };
 		0B57EC2D1D9AA86800D0AD23 /* CookieAuthenticationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CookieAuthenticationTest.m; sourceTree = "<group>"; };
 		0B62685E1EE9AA3700B81D67 /* LRCookieSignIn+Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "LRCookieSignIn+Test.h"; sourceTree = "<group>"; };
+		0B6268611EE9AAF500B81D67 /* ParseAuthTokenTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ParseAuthTokenTest.m; sourceTree = "<group>"; };
 		18CD854F54CBDD248C048762 /* Pods-mobile-sdk-Test.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mobile-sdk-Test.debug.xcconfig"; path = "Pods/Target Support Files/Pods-mobile-sdk-Test/Pods-mobile-sdk-Test.debug.xcconfig"; sourceTree = "<group>"; };
 		38316EDF65692D8428B60858 /* Pods-mobile-sdk-Liferay iOS SDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mobile-sdk-Liferay iOS SDK.debug.xcconfig"; path = "Pods/Target Support Files/Pods-mobile-sdk-Liferay iOS SDK/Pods-mobile-sdk-Liferay iOS SDK.debug.xcconfig"; sourceTree = "<group>"; };
 		8B7FD4FF85FE802EBA325FBD /* Pods-mobile-sdk-Liferay iOS SDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mobile-sdk-Liferay iOS SDK.release.xcconfig"; path = "Pods/Target Support Files/Pods-mobile-sdk-Liferay iOS SDK/Pods-mobile-sdk-Liferay iOS SDK.release.xcconfig"; sourceTree = "<group>"; };
@@ -1943,6 +1945,7 @@
 				CC2E77DF1A3769A9001890A9 /* UnauthenticatedServiceTest.m */,
 				CC5A58501C9B247900AD2FB4 /* ValidatorTest.m */,
 				0B62685E1EE9AA3700B81D67 /* LRCookieSignIn+Test.h */,
+				0B6268611EE9AAF500B81D67 /* ParseAuthTokenTest.m */,
 			);
 			path = Test;
 			sourceTree = SOURCE_ROOT;
@@ -3248,6 +3251,7 @@
 				CC941D061C84EB680029C4A6 /* LRShoppingOrderService_v7.m in Sources */,
 				CC03FCE818ED7DCD00F3F16C /* LRPollsVoteService_v62.m in Sources */,
 				CC03FCC418ED7DCD00F3F16C /* LRDLFolderService_v62.m in Sources */,
+				0B6268621EE9AAF500B81D67 /* ParseAuthTokenTest.m in Sources */,
 				CC03FCB918ED7DCD00F3F16C /* LRContactService_v62.m in Sources */,
 				CC1954B41B66B79E0000EBEE /* LRDownloadDelegate.m in Sources */,
 				CC03FCE118ED7DCD00F3F16C /* LROrganizationService_v62.m in Sources */,
@@ -3557,7 +3561,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -3589,7 +3593,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/ios/Liferay iOS SDK.xcodeproj/project.pbxproj
+++ b/ios/Liferay iOS SDK.xcodeproj/project.pbxproj
@@ -290,6 +290,7 @@
 		0B57EC2A1D9AA81D00D0AD23 /* LRCookieSignIn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LRCookieSignIn.h; sourceTree = "<group>"; };
 		0B57EC2B1D9AA81D00D0AD23 /* LRCookieSignIn.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LRCookieSignIn.m; sourceTree = "<group>"; };
 		0B57EC2D1D9AA86800D0AD23 /* CookieAuthenticationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CookieAuthenticationTest.m; sourceTree = "<group>"; };
+		0B62685E1EE9AA3700B81D67 /* LRCookieSignIn+Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "LRCookieSignIn+Test.h"; sourceTree = "<group>"; };
 		18CD854F54CBDD248C048762 /* Pods-mobile-sdk-Test.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mobile-sdk-Test.debug.xcconfig"; path = "Pods/Target Support Files/Pods-mobile-sdk-Test/Pods-mobile-sdk-Test.debug.xcconfig"; sourceTree = "<group>"; };
 		38316EDF65692D8428B60858 /* Pods-mobile-sdk-Liferay iOS SDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mobile-sdk-Liferay iOS SDK.debug.xcconfig"; path = "Pods/Target Support Files/Pods-mobile-sdk-Liferay iOS SDK/Pods-mobile-sdk-Liferay iOS SDK.debug.xcconfig"; sourceTree = "<group>"; };
 		8B7FD4FF85FE802EBA325FBD /* Pods-mobile-sdk-Liferay iOS SDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mobile-sdk-Liferay iOS SDK.release.xcconfig"; path = "Pods/Target Support Files/Pods-mobile-sdk-Liferay iOS SDK/Pods-mobile-sdk-Liferay iOS SDK.release.xcconfig"; sourceTree = "<group>"; };
@@ -1941,6 +1942,7 @@
 				CC2E77DE1A3769A9001890A9 /* SpecialCharsTest.m */,
 				CC2E77DF1A3769A9001890A9 /* UnauthenticatedServiceTest.m */,
 				CC5A58501C9B247900AD2FB4 /* ValidatorTest.m */,
+				0B62685E1EE9AA3700B81D67 /* LRCookieSignIn+Test.h */,
 			);
 			path = Test;
 			sourceTree = SOURCE_ROOT;

--- a/ios/Source/Core/Auth/LRCookieSignIn.m
+++ b/ios/Source/Core/Auth/LRCookieSignIn.m
@@ -18,8 +18,6 @@
 #import "LRError.h"
 #import "LRHttpUtil.h"
 
-const int AUTH_TOKEN_LENGTH = 8;
-
 @interface LRCookieSignIn() <NSURLSessionDelegate,
 		NSURLSessionDataDelegate, NSURLSessionTaskDelegate>
 
@@ -157,13 +155,23 @@ const int AUTH_TOKEN_LENGTH = 8;
 	NSString *html = [[NSString alloc]initWithData:htmlData
 		encoding:NSUTF8StringEncoding];
 
-	NSRange range = [html rangeOfString:@"Liferay.authToken=\""];
+	NSRegularExpression *regex = [NSRegularExpression
+		regularExpressionWithPattern:@"Liferay.authToken\\s*=\\s*[\"'](.{8})[\"']"
+		options:0 error:nil];
+
+	NSTextCheckingResult *match = [regex firstMatchInString:html
+		options:0 range:NSMakeRange(0, html.length)];
+
+	if (match.numberOfRanges < 2) {
+		return nil;
+	}
+
+	NSRange range = [match rangeAtIndex:1];
 
 	if (range.location == NSNotFound) {
 		return nil;
 	}
 
-	range = NSMakeRange(range.location + range.length, AUTH_TOKEN_LENGTH);
 	return [html substringWithRange:range];
 }
 

--- a/ios/Source/Core/Auth/LRCookieSignIn.m
+++ b/ios/Source/Core/Auth/LRCookieSignIn.m
@@ -123,7 +123,9 @@
 		[self.callback onFailure:error];
 	}
 	else {
-		NSString *authToken = [self _getAuthToken:self.responseData];
+		NSString *html = [[NSString alloc]initWithData: self.responseData
+			encoding:NSUTF8StringEncoding];
+		NSString *authToken = [self _getAuthToken:html];
 
 		if (!authToken) {
 			error = [LRError errorWithCode:400 description:@"Failed to get the auth token"];
@@ -151,9 +153,7 @@
 	}
 }
 
-- (NSString *)_getAuthToken:(NSData *)htmlData {
-	NSString *html = [[NSString alloc]initWithData:htmlData
-		encoding:NSUTF8StringEncoding];
+- (NSString *)_getAuthToken:(NSString *)html {
 
 	NSRegularExpression *regex = [NSRegularExpression
 		regularExpressionWithPattern:@"Liferay.authToken\\s*=\\s*[\"'](.{8})[\"']"

--- a/ios/Test/LRCookieSignIn+Test.h
+++ b/ios/Test/LRCookieSignIn+Test.h
@@ -1,0 +1,17 @@
+//
+//  LRCookieSignIn+Test.h
+//  Liferay iOS SDK
+//
+//  Created by Victor Galán on 08/06/2017.
+//  Copyright © 2017 Liferay Inc. All rights reserved.
+//
+
+#import "LRCookieSignIn.h"
+
+
+@interface LRCookieSignIn (Test)
+
+
+- (NSString *)_getAuthToken:(NSString *)html;
+
+@end

--- a/ios/Test/ParseAuthTokenTest.m
+++ b/ios/Test/ParseAuthTokenTest.m
@@ -1,0 +1,83 @@
+//
+//  ParseAuthTokenTest.m
+//  Liferay iOS SDK
+//
+//  Created by Victor Galán on 08/06/2017.
+//  Copyright © 2017 Liferay Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "LRCookieSignIn+Test.h"
+#import "LRCookieSignIn.h"
+
+@interface ParseAuthTokenTest : XCTestCase
+
+@end
+
+@implementation ParseAuthTokenTest
+
+- (void)testParseAuthTokenWithQuotes {
+	LRCookieSignIn *signIn = [LRCookieSignIn new];
+	NSString *tokenString = @"Liferay.authToken=\"12345678\"";
+
+	NSString *parsedToken = [signIn _getAuthToken: tokenString];
+
+	XCTAssertTrue([parsedToken isEqualToString:@"12345678"]);
+}
+
+- (void)testParseAuthTokenWithSimpleQuotes {
+	LRCookieSignIn *signIn = [LRCookieSignIn new];
+	NSString *tokenString = @"Liferay.authToken='12345678'";
+
+	NSString *parsedToken = [signIn _getAuthToken: tokenString];
+
+	XCTAssertTrue([parsedToken isEqualToString:@"12345678"]);
+}
+
+- (void)testParseAuthTokenWithQuotesAndSpaces {
+	LRCookieSignIn *signIn = [LRCookieSignIn new];
+	NSString *tokenString = @"   Liferay.authToken=    \"12345678\"  ";
+
+	NSString *parsedToken = [signIn _getAuthToken: tokenString];
+
+	XCTAssertTrue([parsedToken isEqualToString:@"12345678"]);
+}
+
+- (void)testParseAuthTokenWithSimpleQuotesAndSpaces {
+	LRCookieSignIn *signIn = [LRCookieSignIn new];
+	NSString *tokenString = @"Liferay.authToken=    '12345678'  ";
+
+	NSString *parsedToken = [signIn _getAuthToken: tokenString];
+
+	XCTAssertTrue([parsedToken isEqualToString:@"12345678"]);
+}
+
+- (void)testParseAuthTokenWithInvalidToken {
+	LRCookieSignIn *signIn = [LRCookieSignIn new];
+	NSString *tokenString = @"Liferay.authToken=\"1234\"";
+
+	NSString *parsedToken = [signIn _getAuthToken: tokenString];
+
+	XCTAssertNil(parsedToken);
+}
+
+- (void)testParseAuthTokenWithoutToken {
+	LRCookieSignIn *signIn = [LRCookieSignIn new];
+	NSString *tokenString = @"This is a string without a token";
+
+	NSString *parsedToken = [signIn _getAuthToken: tokenString];
+
+	XCTAssertNil(parsedToken);
+}
+
+- (void)testParseAuthTokenWithTokenAndMoreStrings {
+	LRCookieSignIn *signIn = [LRCookieSignIn new];
+	NSString *tokenString = @"This is a test stringLiferay.authToken=    '12345678'  this is a test string";
+
+	NSString *parsedToken = [signIn _getAuthToken: tokenString];
+
+	XCTAssertTrue([parsedToken isEqualToString:@"12345678"]);
+}
+
+
+@end


### PR DESCRIPTION
Hey
I've changed the way we parsed the auth token from the html, currently, we only rely on the string so if the authToken comes in a different format it won't parse it properly

