### PR TITLE
Client credentials flow doesn't return refresh token

### DIFF
--- a/ios/Source/Core/Auth/LROAuth2SignIn.h
+++ b/ios/Source/Core/Auth/LROAuth2SignIn.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 	callback:(nullable LRSessionHandler)callback error:(NSError *_Nullable *_Nullable)error;
 
 + (LRSession * _Nullable)clientCredentialsSignInWithSession:(LRSession *)session
-	clientId:(NSString *)clientId clientSecret:(NSString *)clientSecret scopes:(NSArray<NSString *> *)scopes
+	clientId:(NSString *)clientId clientSecret:(NSString *)clientSecret scopes:(NSArray<NSString *> *_Nullable)scopes
 	callback:(nullable LRSessionHandler)callback error:(NSError *_Nullable *_Nullable)error;
 
 + (LRSession * _Nullable)refreshTokenWithSession:(LRSession *)session

--- a/ios/Source/Core/Auth/LROAuth2SignIn.m
+++ b/ios/Source/Core/Auth/LROAuth2SignIn.m
@@ -114,6 +114,11 @@ static NSString *_AUTHORIZATION_PATH;
 	LROAuth2Authentication *authentication = session.authentication;
 	OIDServiceConfiguration *serviceConfig = [self serviceConfigurationWithSession:session];
 
+	if ([self isClientCredentialsAuthentication:authentication]) {
+		return [self clientCredentialsSignInWithSession:session clientId:authentication.clientId
+			clientSecret:authentication.clientSecret scopes:scopes callback:callback error:error];
+	}
+
 	OIDTokenRequest *tokenRequest = [[OIDTokenRequest alloc] initWithConfiguration:serviceConfig
 		grantType:OIDGrantTypeRefreshToken authorizationCode:nil redirectURL:nil clientID:authentication.clientId
 		clientSecret:authentication.clientSecret scopes:scopes
@@ -232,6 +237,11 @@ static NSString *_AUTHORIZATION_PATH;
 
 	return [[OIDServiceConfiguration alloc] initWithAuthorizationEndpoint:authorizationEndpoint
 		tokenEndpoint:tokenEndpoint];
+}
+
++ (BOOL)isClientCredentialsAuthentication:(LROAuth2Authentication *)auth {
+	// Tokens obtained with clientCredentials flow doesn't have refreshtoken
+	return auth.refreshToken.length == 0;
 }
 
 @end

--- a/ios/Source/Core/Auth/LROAuth2SignIn.m
+++ b/ios/Source/Core/Auth/LROAuth2SignIn.m
@@ -142,10 +142,9 @@ static NSString *_AUTHORIZATION_PATH;
 				callback(nil, error);
 			}
 			else {
-				LROAuth2Authentication *auth = [[LROAuth2Authentication alloc]
-					initWithAccessToken:tokenResponse.accessToken
-					refreshToken:tokenResponse.refreshToken scope:tokenResponse.scope
-					accessTokenExpirationDate:tokenResponse.accessTokenExpirationDate
+				LROAuth2Authentication *auth = [self createOrUpdateAuthentication:session.authentication
+					accessToken:tokenResponse.accessToken refreshToken:tokenResponse.refreshToken
+					scope:tokenResponse.scope accessTokenExpirationDate:tokenResponse.accessTokenExpirationDate
 					clientId:tokenResponse.request.clientID clientSecret:tokenResponse.request.clientSecret];
 
 				session.authentication = auth;
@@ -174,10 +173,9 @@ static NSString *_AUTHORIZATION_PATH;
 				localError = e;
 			}
 			else {
-				auth = [[LROAuth2Authentication alloc]
-					initWithAccessToken:tokenResponse.accessToken
-					refreshToken:tokenResponse.refreshToken scope:tokenResponse.scope
-					accessTokenExpirationDate:tokenResponse.accessTokenExpirationDate
+				auth = [self createOrUpdateAuthentication:session.authentication
+					accessToken:tokenResponse.accessToken refreshToken:tokenResponse.refreshToken
+					scope:tokenResponse.scope accessTokenExpirationDate:tokenResponse.accessTokenExpirationDate
 					clientId:tokenResponse.request.clientID clientSecret:tokenResponse.request.clientSecret];
 			}
 			dispatch_semaphore_signal(syncSemaphore);
@@ -193,6 +191,31 @@ static NSString *_AUTHORIZATION_PATH;
 		*error = localError;
 		return nil;
 	}
+}
+
++ (LROAuth2Authentication *)createOrUpdateAuthentication:(id<LRAuthentication>)authentication
+	accessToken:(NSString *)accessToken refreshToken:(NSString *)refreshToken scope:(NSString *)scope
+	accessTokenExpirationDate:(NSDate *)accessTokenExpirationDate clientId:(NSString *)clientId
+	clientSecret:(NSString *)clientSecret {
+
+	if ([authentication isKindOfClass:[LROAuth2Authentication class]]) {
+		LROAuth2Authentication *oauth2Auth = (LROAuth2Authentication *) authentication;
+
+		oauth2Auth.accessToken = accessToken;
+		oauth2Auth.refreshToken = refreshToken;
+		oauth2Auth.scope = scope;
+		oauth2Auth.accessTokenExpirationDate = accessTokenExpirationDate;
+		oauth2Auth.clientId = clientId;
+		oauth2Auth.clientSecret = clientSecret;
+
+		return oauth2Auth;
+	}
+
+	return [[LROAuth2Authentication alloc]
+		initWithAccessToken:accessToken
+		refreshToken:refreshToken scope:scope
+		accessTokenExpirationDate:accessTokenExpirationDate
+		clientId:clientId clientSecret:clientSecret];
 }
 
 + (OIDServiceConfiguration *)serviceConfigurationWithSession:(LRSession *)session {


### PR DESCRIPTION
When the authentication is obtained using client credentials flow, it doesn't return refresh token.

I've added a check so that if the authentication doesn't have refresh token it will request another token using the client credentials flow again 